### PR TITLE
Fixed : Reader onScroll crash

### DIFF
--- a/folioreader/src/main/java/com/folioreader/ui/folio/activity/FolioActivity.kt
+++ b/folioreader/src/main/java/com/folioreader/ui/folio/activity/FolioActivity.kt
@@ -836,15 +836,15 @@ class FolioActivity : AppCompatActivity(), FolioActivityCallback, MediaControlle
                     Log.v(LOG_TAG, "-> onPageScrollStateChanged -> DirectionalViewpager -> " +
                             "position = " + position)
 
-                    var folioPageFragment = mFolioPageFragmentAdapter!!.getItem(position - 1) as FolioPageFragment
-                    if (folioPageFragment != null) {
+                    var folioPageFragment = mFolioPageFragmentAdapter!!.getItem(position - 1)
+                    if (folioPageFragment != null && folioPageFragment is FolioPageFragment) {
                         folioPageFragment.scrollToLast()
                         if (folioPageFragment.mWebview != null)
                             folioPageFragment.mWebview!!.dismissPopupWindow()
                     }
 
-                    folioPageFragment = mFolioPageFragmentAdapter!!.getItem(position + 1) as FolioPageFragment
-                    if (folioPageFragment != null) {
+                    folioPageFragment = mFolioPageFragmentAdapter!!.getItem(position + 1)
+                    if (folioPageFragment != null && folioPageFragment is FolioPageFragment) {
                         folioPageFragment.scrollToFirst()
                         if (folioPageFragment.mWebview != null)
                             folioPageFragment.mWebview!!.dismissPopupWindow()


### PR DESCRIPTION
sometime value passed in getItem() is -1 or listItemSize+1 and it was returning null which was causing casting exceptions.