### PR TITLE
PM-10489 | Hide search cta from actionbar

### DIFF
--- a/folioreader/res/menu/menu_main.xml
+++ b/folioreader/res/menu/menu_main.xml
@@ -8,6 +8,7 @@
         android:id="@+id/itemSearch"
         android:icon="@drawable/ic_search"
         android:title="@string/menu_item_search"
+        android:visible="false"
         app:showAsAction="ifRoom"
         tools:showAsAction="always" />
 


### PR DESCRIPTION
**Associated Issue:**
https://wbdigital.atlassian.net/browse/PM-10489

**Screenshots (if applicable):**
<img width="404" alt="Screenshot 2019-11-14 at 3 43 30 PM" src="https://user-images.githubusercontent.com/54415927/68848105-bc0dda00-06f5-11ea-855e-675fdb718fb6.png">

**Testing steps (for devs doing code review)**
In Folio reader Search CTA should not be visible in actionbar. As shown in screenshot above