### PR TITLE
Fix nullability issues with SDK 29

### DIFF
--- a/r2-streamer-kotlin/src/main/java/org/readium/r2/streamer/server/Server.kt
+++ b/r2-streamer-kotlin/src/main/java/org/readium/r2/streamer/server/Server.kt
@@ -44,10 +44,10 @@ abstract class AbstractServer(private var port: Int) : RouterNanoHTTPD(port) {
 
     private fun addFont(name: String, assets: AssetManager, context: Context) {
         val inputStream = assets.open("fonts/$name")
-        val dir = File(context.getExternalFilesDir(null).path + "/fonts/")
+        val dir = File(context.getExternalFilesDir(null)?.path + "/fonts/")
         dir.mkdirs()
-        inputStream.toFile(context.getExternalFilesDir(null).path + "/fonts/" + name)
-        val file = File(context.getExternalFilesDir(null).path + "/fonts/" + name)
+        inputStream.toFile(context.getExternalFilesDir(null)?.path + "/fonts/" + name)
+        val file = File(context.getExternalFilesDir(null)?.path + "/fonts/" + name)
         fonts.add(name, file)
     }
 

--- a/r2-streamer-kotlin/src/main/java/org/readium/r2/streamer/server/Server.kt
+++ b/r2-streamer-kotlin/src/main/java/org/readium/r2/streamer/server/Server.kt
@@ -44,10 +44,10 @@ abstract class AbstractServer(private var port: Int) : RouterNanoHTTPD(port) {
 
     private fun addFont(name: String, assets: AssetManager, context: Context) {
         val inputStream = assets.open("fonts/$name")
-        val dir = File(context.getExternalFilesDir(null)?.path + "/fonts/")
+        val dir = File(context.getExternalFilesDir(null)!!.path + "/fonts/")
         dir.mkdirs()
-        inputStream.toFile(context.getExternalFilesDir(null)?.path + "/fonts/" + name)
-        val file = File(context.getExternalFilesDir(null)?.path + "/fonts/" + name)
+        inputStream.toFile(context.getExternalFilesDir(null)!!.path + "/fonts/" + name)
+        val file = File(context.getExternalFilesDir(null)!!.path + "/fonts/" + name)
         fonts.add(name, file)
     }
 

--- a/r2-streamer-kotlin/src/main/java/org/readium/r2/streamer/server/handler/FontHandler.kt
+++ b/r2-streamer-kotlin/src/main/java/org/readium/r2/streamer/server/handler/FontHandler.kt
@@ -58,7 +58,7 @@ class FontHandler : RouterNanoHTTPD.DefaultHandler() {
         var mimeType = "application/vnd.ms-opentype"
         if (extension != null) {
             try {
-                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)!!
             } catch (e: Exception) {
                 when (extension) {
                     ".otf" -> mimeType = "application/vnd.ms-opentype"

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,8 +6,8 @@ versions.projectVersionCode = 1
 versions.projectVersionName = "1.0"
 
 versions.androidMinSdkVersion = 21
-versions.androidCompileSdkVersion = 28
-versions.androidTargetSdkVersion = 28
+versions.androidCompileSdkVersion = 29
+versions.androidTargetSdkVersion = 29
 versions.androidSupportLibVersion = "28.0.0"
 
 versions.constraintLayoutVersion = "1.1.3"


### PR DESCRIPTION
Changing the compile SDK to 29 broke some things. These changes are functionally identical to the previous code - the app will still crash - but they allow the app to compile.